### PR TITLE
Updating path relative to main terraform module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ resource "google_compute_network" "swarm" {
 }
 
 data "template_file" "docker_conf" {
-  template = "${file("conf/docker.tpl")}"
+  template = "${file("${path.module}/conf/docker.tpl")}"
 
   vars {
     ip = "${var.docker_api_ip}"
@@ -19,7 +19,7 @@ data "template_file" "docker_conf" {
 }
 
 data "external" "swarm_tokens" {
-  program = ["./scripts/fetch-tokens.sh"]
+  program = ["${path.module}/scripts/fetch-tokens.sh"]
 
   query = {
     host = "${google_compute_instance.manager.0.network_interface.0.access_config.0.assigned_nat_ip}"


### PR DESCRIPTION
Hello,

I wanted to use your module in my TF configuration this way : 

```
module "stack" {
  source = "github.com/stefanprodan/swarm-gcp-faas"
  [.... vars .....]
}
```

The problem is that you didn't defined the paths relative to the module installation path in your code but relative to the main.tf path.. so I got errors like this : 

> * module.stack.data.template_file.docker_conf: file: open conf/docker.tpl: no such file or directory in:
> 
> ${file("conf/docker.tpl")}